### PR TITLE
Rename “All Rooms” in Announcements page

### DIFF
--- a/frontend/src/components/pages/announcements/AnnouncementsGroups.tsx
+++ b/frontend/src/components/pages/announcements/AnnouncementsGroups.tsx
@@ -32,7 +32,7 @@ interface ProcessedGroupAnnouncements {
   groups: GroupAnnouncements;
 }
 
-const formatRooms = (roomIDs: number[]) => {
+export const formatRooms = (roomIDs: number[]) => {
   // Map each room ID to its formatted string
   const formattedRooms = roomIDs.map((id) => `Room ${id}`);
   // Join the formatted room strings with commas

--- a/frontend/src/components/pages/announcements/AnnouncementsView.tsx
+++ b/frontend/src/components/pages/announcements/AnnouncementsView.tsx
@@ -111,7 +111,9 @@ const AnnouncementsView = ({
           alignItems="center"
           justifyContent="space-between"
         >
-          <h1 style={{ fontSize: "24px" }}>{selectedGroup === ""? "All Rooms": formatRooms(rooms)}</h1>
+          <h1 style={{ fontSize: "24px" }}>
+            {selectedGroup === "" ? "All Rooms" : formatRooms(rooms)}
+          </h1>
           <IconButton
             aria-label="info"
             color="purple.main"

--- a/frontend/src/components/pages/announcements/AnnouncementsView.tsx
+++ b/frontend/src/components/pages/announcements/AnnouncementsView.tsx
@@ -13,6 +13,7 @@ import {
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import { GroupAnnouncements } from "../../../types/NotificationTypes";
+import { formatRooms } from "./AnnouncementsGroups";
 
 const MessageInput = ({
   handlePost,
@@ -98,6 +99,7 @@ const AnnouncementsView = ({
   announcements,
   selectedGroup,
 }: Props): React.ReactElement => {
+  const rooms = selectedGroup.split(",").map(Number);
   return (
     <Box h="100vh" w="100%">
       <Flex align="left" flexDir="column" h="100%">
@@ -109,7 +111,7 @@ const AnnouncementsView = ({
           alignItems="center"
           justifyContent="space-between"
         >
-          <h1 style={{ fontSize: "24px" }}>All Rooms</h1>
+          <h1 style={{ fontSize: "24px" }}>{selectedGroup === ""? "All Rooms": formatRooms(rooms)}</h1>
           <IconButton
             aria-label="info"
             color="purple.main"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Rename “All Rooms” in Announcements page](https://www.notion.so/uwblueprintexecs/Rename-All-Rooms-in-Announcements-page-d6a819f50a1247b1aa631c219d9df55a?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Title displays correct Room when group is clicked
* Default (when no group is selected) is set to "All Rooms"

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to Announcements
2. Should see "All Rooms" in the right panel
3. Clicking on Groups should change the title to match group name

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* n/a


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

![Screenshot 2024-05-27 at 9 38 01 PM](https://github.com/uwblueprint/marillac-place/assets/73265053/639d49d2-33e8-416a-a4df-4f7d400c0412)

![Screenshot 2024-05-27 at 9 38 51 PM](https://github.com/uwblueprint/marillac-place/assets/73265053/79733d00-2e0f-405d-893e-0d95dc77b3f0)

![Screenshot 2024-05-27 at 9 38 57 PM](https://github.com/uwblueprint/marillac-place/assets/73265053/71e8a1e5-0d08-40f6-8442-52c6dd7d1693)
