### PR TITLE
Fix Inconsistent Sidebar Spacing

### DIFF
--- a/frontend/src/components/pages/announcements/AnnouncementsPage.tsx
+++ b/frontend/src/components/pages/announcements/AnnouncementsPage.tsx
@@ -16,15 +16,17 @@ const AnnouncementsPage = (): React.ReactElement => {
   }, []);
 
   return (
-    <Flex flexDir="row" alignItems="flex-start" w="100%">
-      <AnnouncementsGroups
-        announcements={announcements}
-        setSelectedGroup={setSelectedGroup}
-      />
-      <AnnouncementsView
-        announcements={announcements}
-        selectedGroup={selectedGroup}
-      />
+    <Flex flexDir="column" flexGrow={1}>
+      <Flex flexDir="row" alignItems="flex-start" w="100%" flexGrow={1}>
+        <AnnouncementsGroups
+          announcements={announcements}
+          setSelectedGroup={setSelectedGroup}
+        />
+        <AnnouncementsView
+          announcements={announcements}
+          selectedGroup={selectedGroup}
+        />
+      </Flex>
     </Flex>
   );
 };

--- a/frontend/src/components/pages/announcements/AnnouncementsView.tsx
+++ b/frontend/src/components/pages/announcements/AnnouncementsView.tsx
@@ -69,10 +69,11 @@ const AnnouncementsList = ({ announcements, selectedGroup }: Props) => {
           key={index}
           backgroundColor="gray.100"
           p="10px"
-          ml="38px"
-          mr="38px"
+          ml="30px"
+          mr="20px"
           mt="20px"
           borderRadius="10px"
+          w="83vh"
         >
           <Flex pl={2} align="center">
             <Avatar name={announcement.author} src="https://bit.ly/2k1H1t6" />

--- a/frontend/src/components/pages/tasks/TasksPage.tsx
+++ b/frontend/src/components/pages/tasks/TasksPage.tsx
@@ -70,7 +70,7 @@ const TasksPage = (): React.ReactElement => {
   }, [taskType]);
 
   return (
-    <Flex flexDir="column" w="100%">
+    <Flex flexDir="column" flexGrow={1}>
       <Tabs variant="horizontal" h="30px" mb={6}>
         <TabList pl={6}>
           <Tab


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix Inconsistent Sidebar Spacing](https://www.notion.so/uwblueprintexecs/Fix-Inconsistent-Sidebar-Spacing-9e65bd63e7734cd185f127d70d1c4d4b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Made parent flex boxes consistent
* Fixed formatting on announcements page that caused components to shift when messages were opened


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Interact with all pages to ensure that sidebar stays static


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Haven't tested using the sidebar from PrivateRoute and manually put it in each page due to auth issues, not sure if that would change anything


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
