### PR TITLE
Create Mutations to Set Resident or Staff to Inactive

### DIFF
--- a/backend/graphql/resolvers/notificationResolvers.ts
+++ b/backend/graphql/resolvers/notificationResolvers.ts
@@ -5,8 +5,11 @@ import INotificationService, {
 } from "../../services/interfaces/notificationService";
 import IResidentService from "../../services/interfaces/residentService";
 import ResidentService from "../../services/implementations/residentService";
+import IUserService from "../../services/interfaces/userService";
+import UserService from "../../services/implementations/userService";
 
-const residentService: IResidentService = new ResidentService();
+const userService: IUserService = new UserService();
+const residentService: IResidentService = new ResidentService(userService);
 const notificationService: INotificationService = new NotificationService(
   residentService,
 );

--- a/backend/graphql/resolvers/residentResolvers.ts
+++ b/backend/graphql/resolvers/residentResolvers.ts
@@ -72,11 +72,13 @@ const residentResolvers = {
     },
     setResidentInactive: async (
       _parent: undefined,
-      {userId}:{userId: string},
-    ) : Promise<ResidentDTO> => {
-      const updatedResident = await residentService.setResidentInactive(parseInt(userId,10));
+      { userId }: { userId: string },
+    ): Promise<ResidentDTO> => {
+      const updatedResident = await residentService.setResidentInactive(
+        parseInt(userId, 10),
+      );
       return updatedResident;
-    }
+    },
   },
 };
 

--- a/backend/graphql/resolvers/residentResolvers.ts
+++ b/backend/graphql/resolvers/residentResolvers.ts
@@ -5,8 +5,11 @@ import IResidentService, {
   UpdateResidentDTO,
   RedeemCreditsResponse,
 } from "../../services/interfaces/residentService";
+import UserService from "../../services/implementations/userService";
+import IUserService from "../../services/interfaces/userService";
 
-const residentService: IResidentService = new ResidentService();
+const userService: IUserService = new UserService();
+const residentService: IResidentService = new ResidentService(userService);
 
 const residentResolvers = {
   Query: {
@@ -67,6 +70,13 @@ const residentResolvers = {
     ): Promise<RedeemCreditsResponse> => {
       return residentService.redeemCredits(parseInt(userId, 10), credits);
     },
+    setResidentInactive: async (
+      _parent: undefined,
+      {userId}:{userId: string},
+    ) : Promise<ResidentDTO> => {
+      const updatedResident = await residentService.setResidentInactive(parseInt(userId,10));
+      return updatedResident;
+    }
   },
 };
 

--- a/backend/graphql/resolvers/staffResolver.ts
+++ b/backend/graphql/resolvers/staffResolver.ts
@@ -57,9 +57,11 @@ const staffResolvers = {
       _parent: undefined,
       { userId }: { userId: string },
     ): Promise<StaffDTO> => {
-      const updatedStaff = await staffService.setStaffInactive(parseInt(userId, 10));
+      const updatedStaff = await staffService.setStaffInactive(
+        parseInt(userId, 10),
+      );
       return updatedStaff;
-    }
+    },
   },
 };
 

--- a/backend/graphql/resolvers/staffResolver.ts
+++ b/backend/graphql/resolvers/staffResolver.ts
@@ -4,8 +4,11 @@ import IStaffService, {
   CreateStaffDTO,
   UpdateStaffDTO,
 } from "../../services/interfaces/staffService";
+import UserService from "../../services/implementations/userService";
+import IUserService from "../../services/interfaces/userService";
 
-const staffService: IStaffService = new StaffService();
+const userService: IUserService = new UserService();
+const staffService: IStaffService = new StaffService(userService);
 
 const staffResolvers = {
   Query: {
@@ -50,6 +53,13 @@ const staffResolvers = {
       const deletedStaff = await staffService.deleteStaff(parseInt(userId, 10));
       return deletedStaff;
     },
+    setStaffInactive: async (
+      _parent: undefined,
+      { userId }: { userId: string },
+    ): Promise<StaffDTO> => {
+      const updatedStaff = await staffService.setStaffInactive(parseInt(userId, 10));
+      return updatedStaff;
+    }
   },
 };
 

--- a/backend/graphql/types/residentType.ts
+++ b/backend/graphql/types/residentType.ts
@@ -72,6 +72,7 @@ const residentType = gql`
     updateResident(userId: ID!, resident: UpdateResidentDTO!): ResidentDTO!
     deleteResident(userId: ID!): ResidentDTO!
     redeemCredits(userId: ID!, credits: Float!): RedeemCreditResponse!
+    setResidentInactive(userId: ID!): ResidentDTO!
   }
 `;
 

--- a/backend/graphql/types/staffType.ts
+++ b/backend/graphql/types/staffType.ts
@@ -45,6 +45,7 @@ const staffType = gql`
     addStaff(staff: CreateStaffDTO!): StaffDTO!
     updateStaff(userId: ID!, staff: UpdateStaffDTO!): StaffDTO!
     deleteStaff(userId: ID!): StaffDTO!
+    setStaffInactive(userId: ID!): StaffDTO!
   }
 `;
 

--- a/backend/services/implementations/residentService.ts
+++ b/backend/services/implementations/residentService.ts
@@ -16,9 +16,7 @@ const Logger = logger(__filename);
 class ResidentService implements IResidentService {
   userService: IUserService;
 
-  constructor(
-    userService: IUserService,
-  ) {
+  constructor(userService: IUserService) {
     this.userService = userService;
   }
 
@@ -378,11 +376,11 @@ class ResidentService implements IResidentService {
   async setResidentInactive(userId: number): Promise<ResidentDTO> {
     try {
       const resident = await prisma.resident.findUnique({
-        where: {userId: userId,},
+        where: { userId },
         include: { user: true },
       });
 
-      if(!resident) {
+      if (!resident) {
         throw new Error(`Resident with ${userId} not found.`);
       }
 
@@ -406,7 +404,9 @@ class ResidentService implements IResidentService {
         isActive: false,
       };
     } catch (error: unknown) {
-      Logger.error(`Failed to set resident inactive. Reason = ${getErrorMessage(error)}`);
+      Logger.error(
+        `Failed to set resident inactive. Reason = ${getErrorMessage(error)}`,
+      );
       throw error;
     }
   }

--- a/backend/services/implementations/residentService.ts
+++ b/backend/services/implementations/residentService.ts
@@ -7,12 +7,21 @@ import IResidentService, {
   UpdateResidentDTO,
   RedeemCreditsResponse,
 } from "../interfaces/residentService";
+import IUserService from "../interfaces/userService";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
 
 const Logger = logger(__filename);
 
 class ResidentService implements IResidentService {
+  userService: IUserService;
+
+  constructor(
+    userService: IUserService,
+  ) {
+    this.userService = userService;
+  }
+
   async addResident(resident: CreateResidentDTO): Promise<ResidentDTO> {
     try {
       const firebaseUser = await firebaseAdmin.auth().createUser({
@@ -362,6 +371,42 @@ class ResidentService implements IResidentService {
           error,
         )}`,
       );
+      throw error;
+    }
+  }
+
+  async setResidentInactive(userId: number): Promise<ResidentDTO> {
+    try {
+      const resident = await prisma.resident.findUnique({
+        where: {userId: userId,},
+        include: { user: true },
+      });
+
+      if(!resident) {
+        throw new Error(`Resident with ${userId} not found.`);
+      }
+
+      this.userService.setUserInactive(userId);
+
+      return {
+        userId: resident.userId,
+        residentId: resident.residentId,
+        birthDate: resident.birthDate,
+        roomNumber: resident.roomNumber,
+        credits: resident.credits,
+        dateJoined: resident.dateJoined,
+        dateLeft: resident.dateLeft,
+        notes: resident.notes,
+        email: resident.user.email,
+        phoneNumber: resident.user.phoneNumber,
+        firstName: resident.user.firstName,
+        lastName: resident.user.lastName,
+        displayName: resident.user.displayName,
+        profilePictureURL: resident.user.profilePictureURL,
+        isActive: false,
+      };
+    } catch (error: unknown) {
+      Logger.error(`Failed to set resident inactive. Reason = ${getErrorMessage(error)}`);
       throw error;
     }
   }

--- a/backend/services/implementations/staffService.ts
+++ b/backend/services/implementations/staffService.ts
@@ -15,9 +15,7 @@ const Logger = logger(__filename);
 class StaffService implements IStaffService {
   userService: IUserService;
 
-  constructor(
-    userService: IUserService,
-  ) {
+  constructor(userService: IUserService) {
     this.userService = userService;
   }
 
@@ -244,14 +242,14 @@ class StaffService implements IStaffService {
     }
   }
 
-  async setStaffInactive(userId: number): Promise<StaffDTO>{
+  async setStaffInactive(userId: number): Promise<StaffDTO> {
     try {
       const staff = await prisma.staff.findUnique({
-        where: { userId: userId },
+        where: { userId },
         include: { user: true },
       });
 
-      if(!staff) {
+      if (!staff) {
         throw new Error(`Staff with userId ${userId} not found.`);
       }
 

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -80,12 +80,12 @@ class UserService implements IUserService {
   async setUserInactive(userId: number): Promise<void> {
     try {
       const user = await prisma.user.update({
-        where: { 
+        where: {
           id: userId,
         },
         data: {
-          isActive: false
-        }
+          isActive: false,
+        },
       });
 
       if (!user) {

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -76,6 +76,28 @@ class UserService implements IUserService {
       throw error;
     }
   }
+
+  async setUserInactive(userId: number): Promise<void> {
+    try {
+      const user = await prisma.user.update({
+        where: { 
+          id: userId,
+        },
+        data: {
+          isActive: false
+        }
+      });
+
+      if (!user) {
+        throw new Error(`User with userId ${userId} not found.`);
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to set user inactive. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default UserService;

--- a/backend/services/interfaces/residentService.ts
+++ b/backend/services/interfaces/residentService.ts
@@ -89,6 +89,14 @@ interface IResidentService {
   getActiveResidents(): Promise<Array<ResidentDTO>>;
 
   /**
+   * Update resident with userId to inactive
+   * @param userId resident's id
+   * @returns resident's type
+   * @throws Error if user type retrieval fails
+   */
+  setResidentInactive(userId: number): Promise<ResidentDTO>;
+
+  /**
    * Redeems certain resident's credits based on resident id
    * @param userId: resident id whose credits are to be redeemed
    *                    and number of credits to be redeemed

--- a/backend/services/interfaces/staffService.ts
+++ b/backend/services/interfaces/staffService.ts
@@ -52,6 +52,14 @@ interface IStaffService {
    * @throws Error if staff retrieval fails
    */
   getStaffByIds(staffIds: number[]): Promise<Array<StaffDTO>>;
+
+  /**
+   * Update staff with staffId to inactive
+   * @param staffId  staff ids
+   * @returns a StaffDTO with staff's information
+   * @throws Error if staff retrieval fails
+   */
+  setStaffInactive(userId: number): Promise<StaffDTO>;
 }
 
 export default IStaffService;

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -70,6 +70,14 @@ interface IUserService {
    * @throws Error if user type retrieval fails
    */
   getUserTypeByAuthId(authId: string): Promise<UserType>;
+
+  /**
+   * Update user with userId to inactive
+   * @param userId user's id
+   * @returns user's type
+   * @throws Error if user type retrieval fails
+   */
+  setUserInactive(userId: number): Promise<void>;
 }
 
 export default IUserService;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Create Mutations to Set Resident or Staff to Inactive](https://www.notion.so/uwblueprintexecs/Create-Mutations-to-Set-Resident-or-Staff-to-Inactive-c470bc8ad54f435e8493ab169953bc0e?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Code to set a resident/staff to inactive in the backend updating interfaces, functions in implementations, and resolvers

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create residents and staff in Postman
2. Use setResidentInactive and setStaffInactive
3. If userId is a resident/staff, it should set isActive to false. Otherwise, error will be returned.
4. Get all residents and staff to make sure it's updated

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
