### PR TITLE
Fill Entries in Edit Tasks Modal Component

### DIFF
--- a/frontend/src/components/pages/tasks/TaskModal.tsx
+++ b/frontend/src/components/pages/tasks/TaskModal.tsx
@@ -22,6 +22,7 @@ type Props = {
 
 type RowData = {
   title: string;
+  location: string;
   dueDate: string;
   creditValue: string;
 };
@@ -159,6 +160,7 @@ const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactE
     if (rowData) {
       setTitle(rowData.title);
       setDueDate(rowData.dueDate);
+      setLocation(rowData.location);
       const { creditValue, ...rest } = rowData;
       const modifiedCreditValue = creditValue.length > 1 ? creditValue.slice(1) : '';
       setMarillacBucks(modifiedCreditValue);
@@ -173,6 +175,7 @@ const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactE
     // TODO: API call to add task
     const newTask = { ...rowData };
     newTask.title = title;
+    newTask.location = location;
     newTask.dueDate = dueDate;
     newTask.creditValue = `$${marillacBucks}`;
   };
@@ -192,6 +195,7 @@ const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactE
     if (rowData) {
       setTitle(rowData.title);
       setDueDate(rowData.dueDate);
+      setLocation(rowData.location);
       const { creditValue, ...rest } = rowData;
       const modifiedCreditValue = creditValue.length > 1 ? creditValue.slice(1) : '';
       setMarillacBucks(modifiedCreditValue);
@@ -249,12 +253,11 @@ const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactE
             onChange={(e) => setLocation(e.target.value)}
             border="solid"
             borderWidth="2px"
-            borderColor="gray.300"
             height="34px"
           >
-            <option value="kitchen">Kitchen</option>
-            <option value="livingRoom">Living Room</option>
-            <option value="washroom">Washroom</option>
+            <option value="Kitchen">Kitchen</option>
+            <option value="Living Room">Living Room</option>
+            <option value="Bathroom">Bathroom</option>
           </Select>
         </FormControl>
         <DateInput
@@ -291,7 +294,9 @@ const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactE
           </Button>
           <Button variant="primary" onClick={ () => {
               handleSubmit();
-              setIsOpen(false);
+              if (title && dueDate && dueTime && marillacBucks) {
+                setIsOpen(false);
+              } 
             }}
             >
             Save

--- a/frontend/src/components/pages/tasks/TaskModal.tsx
+++ b/frontend/src/components/pages/tasks/TaskModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Text,
   Button,
@@ -16,6 +16,14 @@ import FormField from "../../common/FormField";
 type Props = {
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  taskType: string;
+  rowData: RowData;
+};
+
+type RowData = {
+  title: string;
+  dueDate: string;
+  creditValue: string;
 };
 
 const generateOptions = () => {
@@ -134,7 +142,7 @@ const DateInput = ({
   );
 };
 
-const TaskModal = ({ isOpen, setIsOpen }: Props): React.ReactElement => {
+const TaskModal = ({ isOpen, setIsOpen, taskType, rowData}: Props): React.ReactElement => {
   const [title, setTitle] = useState("");
   const [location, setLocation] = useState("");
   const [dueDate, setDueDate] = useState("");
@@ -142,8 +150,20 @@ const TaskModal = ({ isOpen, setIsOpen }: Props): React.ReactElement => {
   const [isAllDay, setIsAllDay] = useState(false);
   const [recurrenceFrequency, setRecurrenceFrequency] = useState("");
   const [marillacBucks, setMarillacBucks] = useState("");
+  const [modalTitle, setModalTitle] = useState("");
 
   const [submitPressed, setSubmitPressed] = useState(false);
+
+  
+  useEffect(() => {
+    if (rowData) {
+      setTitle(rowData.title);
+      setDueDate(rowData.dueDate);
+      const { creditValue, ...rest } = rowData;
+      const modifiedCreditValue = creditValue.length > 1 ? creditValue.slice(1) : '';
+      setMarillacBucks(modifiedCreditValue);
+    }
+  }, [rowData]);
 
   const handleSubmit = () => {
     setSubmitPressed(true);
@@ -151,18 +171,31 @@ const TaskModal = ({ isOpen, setIsOpen }: Props): React.ReactElement => {
       // TODO: Add error handling
     }
     // TODO: API call to add task
+    const newTask = { ...rowData };
+    newTask.title = title;
+    newTask.dueDate = dueDate;
+    newTask.creditValue = `$${marillacBucks}`;
   };
 
-  const resetFormState = () => {
-    setTitle("");
-    setLocation("");
-    setDueDate("");
-    setDueTime("");
-    setIsAllDay(false);
-    setRecurrenceFrequency("");
-    setMarillacBucks("");
+  // const resetFormState = () => {
+  //   setTitle("");
+  //   setLocation("");
+  //   setDueDate("");
+  //   setDueTime("");
+  //   setIsAllDay(false);
+  //   setRecurrenceFrequency("");
+  //   setMarillacBucks("");
+  //   setSubmitPressed(false);
+  // };
 
-    setSubmitPressed(false);
+  const resetFormState = () => {
+    if (rowData) {
+      setTitle(rowData.title);
+      setDueDate(rowData.dueDate);
+      const { creditValue, ...rest } = rowData;
+      const modifiedCreditValue = creditValue.length > 1 ? creditValue.slice(1) : '';
+      setMarillacBucks(modifiedCreditValue);
+    }
   };
 
   const handleMoneyInput = () => {
@@ -177,16 +210,28 @@ const TaskModal = ({ isOpen, setIsOpen }: Props): React.ReactElement => {
   // delete task api stuff
   const handleDelete = () => {};
 
+  useEffect(() => {
+    if (taskType === "REQUIRED") {
+      setModalTitle("Edit Required Task");
+    } else if (taskType === "OPTIONAL") {
+      setModalTitle("Edit Optional Task");
+    } else if (taskType === "CUSTOM") {
+      setModalTitle("Edit Custom Task");
+    } else if (taskType === "CHORE") {
+      setModalTitle("Edit Chore");
+    }
+  }, [taskType]);
+
   return (
     <ModalContainer 
-      title="Edit Chore"
+      title={modalTitle}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       onDelete={handleDelete}
     >
       <Flex flexDir="column" gap="20px">
         <FormField
-          label="Task Name"
+          label="Name"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           submitPressed={submitPressed}

--- a/frontend/src/components/pages/tasks/TasksPage.tsx
+++ b/frontend/src/components/pages/tasks/TasksPage.tsx
@@ -45,6 +45,7 @@ const TasksPage = (): React.ReactElement => {
   const [taskType, setTaskType] = useState<TaskType>("REQUIRED");
   const [taskData, setTaskData] = useState<TableData[]>([]);
   const [taskDataColumns, setTaskDataColumns] = useState<ColumnInfoTypes[]>([]);
+  const [selectedRowData, setSelectedRowData] = useState<any | null>(null);
 
   useEffect(() => {
     // TODO: Fetch the task data from the API instead of using mock data
@@ -128,9 +129,12 @@ const TasksPage = (): React.ReactElement => {
           data={taskData}
           columnInfo={taskDataColumns}
           maxResults={8}
-          onEdit={() => {setIsModalOpen(true);}}
+          onEdit={(row: any) => {
+            setIsModalOpen(true);
+            setSelectedRowData(row);
+          }}
         />
-        <TaskModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+        <TaskModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} taskType={taskType} rowData={selectedRowData} />
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fill Entries in Edit Tasks Modal Component](https://www.notion.so/uwblueprintexecs/Fill-Entries-in-Edit-Tasks-Modal-Component-e962f088012b4267a2a529e71b125211?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed title of the modal (Edit Task/Chore) to match the page
* Task data appears in the fields when the edit button is clicked
* Only able to save when all required fields are filled in (error shown if left blank)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to tasks page
2. Click edit button
3. See that the fields show up
4. Press save

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
