### PR TITLE
Add Get Participants by Rooms Resolver

### DIFF
--- a/backend/resolvers/participantResolver.ts
+++ b/backend/resolvers/participantResolver.ts
@@ -11,12 +11,18 @@ const participantResolver = {
     getPastParticipants: async (): Promise<Participant[]> => {
       return participantService.getPastParticipants();
     },
-    getParticipantByRoom: async(
+    getParticipantByRoom: async (
       _parent: undefined,
       { room_number }: { room_number: number }
     ): Promise<Participant | null> => {
       return participantService.getParticipantByRoom(room_number);
-    }
+    },
+    getParticipantsByRooms: async (
+      _parent: undefined,
+      { room_numbers }: { room_numbers: number[] }
+    ): Promise<Record<number, number | null>> => {
+      return participantService.getParticipantsByRooms(room_numbers);
+    },
   },
   Mutation: {
     createParticipant: async (
@@ -31,13 +37,13 @@ const participantResolver = {
         room_number: number;
         arrival_date: string;
         password: string;
-      },
+      }
     ): Promise<boolean> => {
       return participantService.createParticipant(
         participant_id,
         room_number,
         arrival_date,
-        password,
+        password
       );
     },
     updateParticipant: async (
@@ -62,7 +68,7 @@ const participantResolver = {
         marillac_bucks?: number;
         marillac_bucks_goal?: number;
         password?: string;
-      },
+      }
     ): Promise<boolean> => {
       return participantService.updateParticipant(
         participant_id,
@@ -73,7 +79,7 @@ const participantResolver = {
         account_removal_date,
         marillac_bucks,
         marillac_bucks_goal,
-        password,
+        password
       );
     },
     updateMarillacBucks: async (
@@ -81,12 +87,12 @@ const participantResolver = {
       {
         participant_id,
         marillac_bucks,
-        reason
+        reason,
       }: {
         participant_id: number;
         marillac_bucks: number;
         reason: string;
-      },
+      }
     ): Promise<boolean> => {
       return participantService.updateMarillacBucks(
         participant_id,
@@ -94,7 +100,7 @@ const participantResolver = {
         reason
       );
     },
-  }
-}
+  },
+};
 
 export default participantResolver;

--- a/backend/services/implementation/participantImplementation.ts
+++ b/backend/services/implementation/participantImplementation.ts
@@ -26,10 +26,7 @@ class ParticipantService implements IParticipantService {
     try {
       const participants = await prisma.participant.findMany({
         where: {
-          OR: [
-            { departure_date: null },
-            { departure_date: { gt: today } }
-          ]
+          OR: [{ departure_date: null }, { departure_date: { gt: today } }],
         },
         orderBy: [{ room_number: "asc" }],
       });
@@ -47,12 +44,9 @@ class ParticipantService implements IParticipantService {
           AND: [
             { room_number },
             {
-              OR: [
-                { departure_date: null },
-                { departure_date: { gt: today } }
-              ]
-            }
-          ]
+              OR: [{ departure_date: null }, { departure_date: { gt: today } }],
+            },
+          ],
         },
       });
       return participant;
@@ -60,58 +54,91 @@ class ParticipantService implements IParticipantService {
       throw new Error("Something went wrong");
     }
   }
-//
-//     async getParticipantById(participantId: string): Promise<Participant | null> {
-//         try {
-//             const participant: Participant | null = await prisma.participant.findUnique(
-//                 {
-//                     where: {
-//                         participantId,
-//                     },
-//                 },
-//             );
-//             return participant;
-//         } catch (err) {
-//             console.log(err);
-//             throw err;
-//         }
-//     }
-//
+
+  async getParticipantsByRooms(
+    room_numbers: number[]
+  ): Promise<Record<number, number | null>> {
+    const today = new Date().toLocaleDateString("en-ca");
+    try {
+      const participants = await prisma.participant.findMany({
+        where: {
+          AND: [
+            { room_number: { in: room_numbers } },
+            {
+              OR: [{ departure_date: null }, { departure_date: { gt: today } }],
+            },
+          ],
+        },
+      });
+
+      // Convert array to object with room numbers as keys and participant IDs as values
+      const result: Record<number, number | null> = {};
+      for (const participant of participants) {
+        result[participant.room_number] = participant.participant_id;
+      }
+
+      // Account for rooms with no participants
+      for (const room_number of room_numbers) {
+        if (!(room_number in result)) {
+          result[room_number] = null;
+        }
+      }
+
+      return result;
+    } catch (err) {
+      throw new Error("Something went wrong");
+    }
+  }
+
+  //
+  //     async getParticipantById(participantId: string): Promise<Participant | null> {
+  //         try {
+  //             const participant: Participant | null = await prisma.participant.findUnique(
+  //                 {
+  //                     where: {
+  //                         participantId,
+  //                     },
+  //                 },
+  //             );
+  //             return participant;
+  //         } catch (err) {
+  //             console.log(err);
+  //             throw err;
+  //         }
+  //     }
+  //
   async createParticipant(
     participant_id: number,
     room_number: number,
     arrival_date: string,
-    password: string,
+    password: string
   ): Promise<boolean> {
     let existingParticipant: Participant | null = null;
     try {
       existingParticipant = await prisma.participant.findUnique({
-        where: { participant_id }
+        where: { participant_id },
       });
     } catch (err) {
       throw new Error("Something went wrong");
     }
     if (existingParticipant) {
-      throw new Error("Participant already exists")
+      throw new Error("Participant already exists");
     }
 
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toISOString().split("T")[0];
     let occupiedRoom: Participant | null = null;
     try {
       occupiedRoom = await prisma.participant.findFirst({
         where: {
           room_number,
-          OR: [
-            { departure_date: null },
-            { departure_date: { gte: today } }
-          ]
-        }
+          OR: [{ departure_date: null }, { departure_date: { gte: today } }],
+        },
       });
     } catch (err) {
       throw new Error("Something went wrong");
     }
     if (occupiedRoom) {
-      throw new Error("Room is occupied")
+      throw new Error("Room is occupied");
     }
 
     try {
@@ -139,16 +166,19 @@ class ParticipantService implements IParticipantService {
     account_removal_date?: string,
     marillac_bucks?: number,
     marillac_bucks_goal?: number,
-    password?: string,
+    password?: string
   ): Promise<boolean> {
     const updatedData: Record<string, any> = {};
     if (room_number) updatedData.room_number = room_number;
     if (arrival_date) updatedData.arrival_date = arrival_date;
     if (departure_date) updatedData.departure_date = departure_date;
-    if (account_creation_date) updatedData.account_creation_date = account_creation_date;
-    if (account_removal_date) updatedData.account_removal_date = account_removal_date;
+    if (account_creation_date)
+      updatedData.account_creation_date = account_creation_date;
+    if (account_removal_date)
+      updatedData.account_removal_date = account_removal_date;
     if (marillac_bucks) updatedData.marillac_bucks = marillac_bucks;
-    if (marillac_bucks_goal) updatedData.marillac_bucks_goal = marillac_bucks_goal;
+    if (marillac_bucks_goal)
+      updatedData.marillac_bucks_goal = marillac_bucks_goal;
     if (password) updatedData.password = password;
 
     try {
@@ -165,7 +195,7 @@ class ParticipantService implements IParticipantService {
   async updateMarillacBucks(
     participant_id: number,
     marillac_bucks: number,
-    reason: string,
+    reason: string
   ): Promise<boolean> {
     try {
       await prisma.participant.update({
@@ -176,42 +206,42 @@ class ParticipantService implements IParticipantService {
     } catch (err) {
       throw new Error("Something went wrong");
     }
-  };
-//
-//     async getParticipantByRoom(roomNumber: number): Promise<Participant | null> {
-//         try {
-//             const participant: Participant | null = await prisma.participant.findFirst(
-//                 {
-//                     where: {
-//                         roomNumber,
-//                     },
-//                 },
-//             );
-//             return participant;
-//         } catch (err) {
-//             console.log(err);
-//             throw err
-//         }
-//     }
-//
-//     async updateParticipantCredit(
-//         participantId: string,
-//         credit: number,
-//     ): Promise<boolean> {
-//         const updatedData: Record<string, any> = {};
-//         if (credit !== undefined) updatedData.credit = credit;
-//         if (!participantId) throw new Error("participantId is required");
-//         try {
-//             await prisma.participant.update({
-//                 where: { participantId },
-//                 data: updatedData,
-//             });
-//             return true;
-//         } catch (err) {
-//             console.log(err);
-//             throw err;
-//         }
-//     }
+  }
+  //
+  //     async getParticipantByRoom(roomNumber: number): Promise<Participant | null> {
+  //         try {
+  //             const participant: Participant | null = await prisma.participant.findFirst(
+  //                 {
+  //                     where: {
+  //                         roomNumber,
+  //                     },
+  //                 },
+  //             );
+  //             return participant;
+  //         } catch (err) {
+  //             console.log(err);
+  //             throw err
+  //         }
+  //     }
+  //
+  //     async updateParticipantCredit(
+  //         participantId: string,
+  //         credit: number,
+  //     ): Promise<boolean> {
+  //         const updatedData: Record<string, any> = {};
+  //         if (credit !== undefined) updatedData.credit = credit;
+  //         if (!participantId) throw new Error("participantId is required");
+  //         try {
+  //             await prisma.participant.update({
+  //                 where: { participantId },
+  //                 data: updatedData,
+  //             });
+  //             return true;
+  //         } catch (err) {
+  //             console.log(err);
+  //             throw err;
+  //         }
+  //     }
 }
 
 export default ParticipantService;

--- a/backend/services/implementation/participantImplementation.ts
+++ b/backend/services/implementation/participantImplementation.ts
@@ -73,16 +73,16 @@ class ParticipantService implements IParticipantService {
 
       // Convert array to object with room numbers as keys and participant IDs as values
       const result: Record<number, number | null> = {};
-      for (const participant of participants) {
+      participants.forEach((participant) => {
         result[participant.room_number] = participant.participant_id;
-      }
+      });
 
-      // Account for rooms with no participants
-      for (const room_number of room_numbers) {
-        if (!(room_number in result)) {
-          result[room_number] = null;
+      // Account for rooms with no participants setting value to null
+      room_numbers.forEach((roomNumber) => {
+        if (!(roomNumber in result)) {
+          result[roomNumber] = null;
         }
-      }
+      });
 
       return result;
     } catch (err) {

--- a/backend/services/interface/participantInterface.ts
+++ b/backend/services/interface/participantInterface.ts
@@ -4,12 +4,15 @@ interface IParticipantService {
   getPastParticipants(): Promise<Participant[]>;
   getCurrentParticipants(): Promise<Participant[]>;
   getParticipantByRoom(room_number: number): Promise<Participant | null>;
-//     getParticipantById(participantId: string): Promise<Participant | null>;
+  getParticipantsByRooms(
+    room_numbers: number[]
+  ): Promise<Record<number, number | null>>;
+  // getParticipantById(participantId: string): Promise<Participant | null>;
   createParticipant(
-      participant_id: number,
-      room_number: number,
-      arrival_date: string,
-      password: string,
+    participant_id: number,
+    room_number: number,
+    arrival_date: string,
+    password: string
   ): Promise<boolean>;
   updateParticipant(
     participant_id: number,
@@ -20,25 +23,25 @@ interface IParticipantService {
     account_removal_date?: string,
     marillac_bucks?: number,
     marillac_bucks_goal?: number,
-    password?: string,
+    password?: string
   ): Promise<boolean>;
   updateMarillacBucks(
     participant_id: number,
     marillac_bucks: number,
-    reason: string,
+    reason: string
   ): Promise<boolean>;
-//     updateParticipantById(
-//         participantId: string,
-//         roomNumber?: number,
-//         arrival?: string,
-//         departure?: string,
-//         password?: string,
-//     ): Promise<boolean>;
-//     getParticipantByRoom(roomNumber: number): Promise<Participant | null>;
-//     updateParticipantCredit(
-//         participantId: string,
-//         credit: number,
-//     ): Promise<boolean>;
+  // updateParticipantById(
+  //   participantId: string,
+  //   roomNumber?: number,
+  //   arrival?: string,
+  //   departure?: string,
+  //   password?: string
+  // ): Promise<boolean>;
+  //     getParticipantByRoom(roomNumber: number): Promise<Participant | null>;
+  //     updateParticipantCredit(
+  //         participantId: string,
+  //         credit: number,
+  //     ): Promise<boolean>;
 }
 
 export default IParticipantService;

--- a/backend/types/resolvers.ts
+++ b/backend/types/resolvers.ts
@@ -5,6 +5,7 @@ const resolvers = gql`
     getPastParticipants: [Participant]
     getCurrentParticipants: [Participant]
     getParticipantByRoom(room_number: Int!): Participant
+    getParticipantsByRooms(room_numbers: [Int!]!): JSON
     getNotes: [Note]
     getAllAnnouncements: [Announcement]
     getTasksByType(type: TaskType!): [Task]
@@ -14,67 +15,64 @@ const resolvers = gql`
     adminLogin(role: String!, password: String!): LoginResponse
     participantLogin(id: Int!, password: String!): LoginResponse
     createParticipant(
-      participant_id: Int!, 
-      room_number: Int!, 
-      arrival_date: String!,
+      participant_id: Int!
+      room_number: Int!
+      arrival_date: String!
       password: String!
     ): Boolean
     updateParticipant(
-      participant_id: Int!,
-      room_number: Int,
-      arrival_date: String,
-      password: String,
-      departure_date: String,
-      account_creation_date: String,
-      account_removal_date: String,
-      marillac_bucks: Int,
-      marillac_bucks_goal: Int,
+      participant_id: Int!
+      room_number: Int
+      arrival_date: String
+      password: String
+      departure_date: String
+      account_creation_date: String
+      account_removal_date: String
+      marillac_bucks: Int
+      marillac_bucks_goal: Int
     ): Boolean
     updateMarillacBucks(
-      participant_id: Int!,
-      marillac_bucks: Int!,
+      participant_id: Int!
+      marillac_bucks: Int!
       reason: String!
     ): Boolean
-    createNote(
-      message: String!,
-      creation_date: String!
-    ): Boolean
+    createNote(message: String!, creation_date: String!): Boolean
     deleteNote(note_id: Int!): Boolean
     createAnnouncement(
-      priority: Priority!,
-      participants: [Int!]!,
-      message: String!,
+      priority: Priority!
+      participants: [Int!]!
+      message: String!
     ): Boolean
     editAnnouncement(
-      announcement_id: Int!,
-      priority: Priority,
-      message: String,
+      announcement_id: Int!
+      priority: Priority
+      message: String
     ): Boolean
     deleteAnnouncement(announcement_id: Int!): Boolean
     createTask(
-      type: TaskType!,
-      name: String!,
-      recurrencePreference: RecurrenceFrequency!,
-      repeatDays: [DayOfWeek!]!,
-      timePreference: TimeOption!,
-      marillacBucks: Int!,
-      deduction: Int!,
-      startTime: String,
-      endTime: String,
-      comment: String,
+      type: TaskType!
+      name: String!
+      recurrencePreference: RecurrenceFrequency!
+      repeatDays: [DayOfWeek!]!
+      timePreference: TimeOption!
+      marillacBucks: Int!
+      deduction: Int!
+      startTime: String
+      endTime: String
+      comment: String
     ): Boolean
     updateTask(
-      id: Int!,
-      type: TaskType,
-      name: String,
-      recurrencePreference: RecurrenceFrequency,
-      repeatDays: [DayOfWeek!],
-      timePreference: TimeOption,
-      marillacBucks: Int,
-      deduction: Int,
-      startTime: String,
-      endTime: String,
-      comment: String,
+      id: Int!
+      type: TaskType
+      name: String
+      recurrencePreference: RecurrenceFrequency
+      repeatDays: [DayOfWeek!]
+      timePreference: TimeOption
+      marillacBucks: Int
+      deduction: Int
+      startTime: String
+      endTime: String
+      comment: String
     ): Boolean
     deleteTaskById(taskId: Int!): Boolean
   }

--- a/backend/utils/getGraphQLMiddleware.ts
+++ b/backend/utils/getGraphQLMiddleware.ts
@@ -1,17 +1,23 @@
 const jwt = require("jsonwebtoken");
 
 function verifyRole(allowedRoles: string[]) {
-  return async function (resolve: any, parent: any, args: any, context: any, info: any) {
+  return async function (
+    resolve: any,
+    parent: any,
+    args: any,
+    context: any,
+    info: any
+  ) {
     const authHeader = context.req.headers.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer")) {
       throw new Error("Missing or invalid authorization header");
     }
 
     try {
-      const token = authHeader.split(" ")[1];
-      const jwt_secret = process.env.JWT_SECRET ?? "";
-      const data: any = jwt.verify(token, jwt_secret);
-      const role = data.role;
+      const TOKEN = authHeader.split(" ")[1];
+      const JWT_SECRET = process.env.JWT_SECRET ?? "";
+      const DATA: any = jwt.verify(TOKEN, JWT_SECRET);
+      const { role } = DATA;
 
       if (!allowedRoles.includes(role)) {
         throw new Error("Request is not authorized");
@@ -30,6 +36,7 @@ export default function getGraphQLMiddleware() {
       getPastParticipants: verifyRole(["admin", "relief"]),
       getCurrentParticipants: verifyRole(["admin", "relief"]),
       getParticipantByRoom: verifyRole(["admin", "relief"]),
+      getParticipantsByRooms: verifyRole(["admin", "relief"]),
       getNotes: verifyRole(["admin", "relief"]),
       getAllAnnouncements: verifyRole(["admin", "relief"]),
       getTasksByType: verifyRole(["admin", "relief"]),
@@ -47,7 +54,7 @@ export default function getGraphQLMiddleware() {
       updateTask: verifyRole(["admin", "relief"]),
       deleteTaskById: verifyRole(["admin", "relief"]),
     },
-  }
+  };
 
   return middleware;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,12 +27,12 @@ import ParticipantLoginPage from "./pages/participant/login/Main";
 
 import NotFound from "./pages/NotFound";
 
-import * as ROUTES from "./constants/routes";
+import * as ROUTES from "./constants/Routes";
 import AdminRoute from "./components/admin/AdminRoute";
 import ParticipantRoute from "./components/participant/ParticipantRoute";
 
 const App = (): React.ReactElement => {
-  const theme =  getChakraTheme();
+  const theme = getChakraTheme();
   const apolloClient = getApolloClient();
 
   return (
@@ -67,7 +67,10 @@ const App = (): React.ReactElement => {
               </AdminRoute>
             }/>
 
-            <Route path={ROUTES.PARTICIPANTS_LOGIN_PAGE} element={<ParticipantLoginPage />} />
+            <Route
+              path={ROUTES.PARTICIPANTS_LOGIN_PAGE}
+              element={<ParticipantLoginPage />}
+            />
 
             <Route path="*" element={<NotFound />} />
           </Switch>

--- a/frontend/src/components/admin/AdminRoute.tsx
+++ b/frontend/src/components/admin/AdminRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from "react-router-dom";
 import { Flex } from "@chakra-ui/react";
 import SideBar from "./SideBar";
 import Notification from "./Notification";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 import { isAdmin, isRelief } from "../../utils/checkRole";
 import Loading from "../../pages/Loading";
 

--- a/frontend/src/components/admin/SideBar.tsx
+++ b/frontend/src/components/admin/SideBar.tsx
@@ -11,14 +11,14 @@ import {
   ModalOverlay,
   ModalContent,
   ModalBody,
-  Text
+  Text,
 } from "@chakra-ui/react";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 
 type SideBarTabProps = {
-  label: string,
-  handleClick: () => void
-}
+  label: string;
+  handleClick: () => void;
+};
 
 function SideBarTab({ label, handleClick }: SideBarTabProps) {
   return (
@@ -36,13 +36,13 @@ function SideBarTab({ label, handleClick }: SideBarTabProps) {
       _selected={{
         fontWeight: 700,
         color: "neutral.0",
-        bg: "secondary.700"
+        bg: "secondary.700",
       }}
     >
       {label}
     </Tab>
   );
-};
+}
 
 type SignOutPopUpProps = {
   cancel: () => void;
@@ -57,39 +57,31 @@ function SignOutPopUp({ cancel }: SignOutPopUpProps) {
 
   return (
     <Modal closeOnOverlayClick={false} isOpen onClose={cancel} isCentered>
-      <ModalOverlay/>
-      <ModalContent
-        boxShadow="xl"
-        borderRadius="16px"
-        width="388px"
-      >
-        <ModalBody
-          padding="30px"
-        >
-          <Text textStyle="web.h2" mb="20px">Sign Out</Text>
-          <Text textStyle="web.b1" mb="20px">Are you sure you want to sign out?</Text>
-          <Flex
-            alignItems="center"
-            justifyContent="flex-end"
-            gap="15px"
-          >
-            <Button
-              variant="white"
-              onClick={cancel}
-            >
-              <Text fontWeight={700} fontSize="14px">Cancel</Text>
+      <ModalOverlay />
+      <ModalContent boxShadow="xl" borderRadius="16px" width="388px">
+        <ModalBody padding="30px">
+          <Text textStyle="web.h2" mb="20px">
+            Sign Out
+          </Text>
+          <Text textStyle="web.b1" mb="20px">
+            Are you sure you want to sign out?
+          </Text>
+          <Flex alignItems="center" justifyContent="flex-end" gap="15px">
+            <Button variant="white" onClick={cancel}>
+              <Text fontWeight={700} fontSize="14px">
+                Cancel
+              </Text>
             </Button>
-            <Button
-              variant="primaryFilled"
-              onClick={ handleSignOut }
-            >
-              <Text fontWeight={700} fontSize="14px" color="white">Sign Out</Text>
+            <Button variant="primaryFilled" onClick={handleSignOut}>
+              <Text fontWeight={700} fontSize="14px" color="white">
+                Sign Out
+              </Text>
             </Button>
           </Flex>
         </ModalBody>
       </ModalContent>
     </Modal>
-  )
+  );
 }
 
 export default function SideBar() {
@@ -97,16 +89,16 @@ export default function SideBar() {
   const [signOut, setSignOut] = useState(false);
 
   const pages = [
-    {label: "Home", route: ROUTES.ADMIN_HOME_PAGE},
-    {label: "Schedule", route: ROUTES.ADMIN_SCHEDULE_PAGE},
-    {label: "Announcements", route: ROUTES.ADMIN_ANNOUNCEMENTS_PAGE},
-    {label: "Participants", route: ROUTES.ADMIN_PARTICIPANTS_PAGE},
-    {label: "Task Library", route: ROUTES.ADMIN_TASKS_PAGE},
-    {label: "Badge Library", route: ROUTES.ADMIN_BADGES_PAGE},
+    { label: "Home", route: ROUTES.ADMIN_HOME_PAGE },
+    { label: "Schedule", route: ROUTES.ADMIN_SCHEDULE_PAGE },
+    { label: "Announcements", route: ROUTES.ADMIN_ANNOUNCEMENTS_PAGE },
+    { label: "Participants", route: ROUTES.ADMIN_PARTICIPANTS_PAGE },
+    { label: "Task Library", route: ROUTES.ADMIN_TASKS_PAGE },
+    { label: "Badge Library", route: ROUTES.ADMIN_BADGES_PAGE },
   ];
 
   const currentPage = pages.findIndex(
-    (page) => page.route === window.location.pathname,
+    (page) => page.route === window.location.pathname
   );
 
   return (
@@ -126,7 +118,11 @@ export default function SideBar() {
       alignItems="left"
     >
       <Flex width="100%" flexDir="column" gap="40px" alignItems="left">
-        <img src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"} alt="Marillac Place Logo" width="85%"/>
+        <img
+          src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"}
+          alt="Marillac Place Logo"
+          width="85%"
+        />
 
         <Tabs
           defaultIndex={currentPage}
@@ -156,8 +152,7 @@ export default function SideBar() {
         Sign out
       </Button>
 
-      {signOut && <SignOutPopUp cancel={() => setSignOut(false)}/>}
+      {signOut && <SignOutPopUp cancel={() => setSignOut(false)} />}
     </Box>
   );
-};
-
+}

--- a/frontend/src/components/participant/ParticipantRoute.tsx
+++ b/frontend/src/components/participant/ParticipantRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { Flex } from "@chakra-ui/react";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 import { isParticipant } from "../../utils/checkRole";
 import Loading from "../../pages/Loading";
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Flex, Text } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
-import * as ROUTES from "../constants/routes";
+import * as ROUTES from "../constants/Routes";
 
 export default function NotFound() {
   const navigate = useNavigate();
@@ -9,19 +9,14 @@ export default function NotFound() {
   function handleClick() {
     const path = window.location.pathname.split("/");
     if (path.length >= 2 && path[1] === "admin") {
-      navigate(ROUTES.ADMIN_LOGIN_PAGE)
+      navigate(ROUTES.ADMIN_LOGIN_PAGE);
     } else {
-      navigate(ROUTES.PARTICIPANTS_LOGIN_PAGE)
+      navigate(ROUTES.PARTICIPANTS_LOGIN_PAGE);
     }
   }
 
   return (
-    <Flex
-      w="100%"
-      h="100vh"
-      alignItems="center"
-      justifyContent="center"
-    >
+    <Flex w="100%" h="100vh" alignItems="center" justifyContent="center">
       <Flex
         width="350px"
         alignItems="center"
@@ -30,9 +25,18 @@ export default function NotFound() {
         gap="20px"
         padding="20px"
       >
-        <img src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"} alt="Marillac Place Logo" width="50%"/>
-        <Text textStyle="web.h2" color="secondary.700" textAlign="center">404 Page Not Found</Text>
-        <Text textStyle="web.b2" color="text.light.primary" textAlign="center">Sorry! The page you are looking for does not exist. If you think something is broken, please report a problem.</Text>
+        <img
+          src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"}
+          alt="Marillac Place Logo"
+          width="50%"
+        />
+        <Text textStyle="web.h2" color="secondary.700" textAlign="center">
+          404 Page Not Found
+        </Text>
+        <Text textStyle="web.b2" color="text.light.primary" textAlign="center">
+          Sorry! The page you are looking for does not exist. If you think
+          something is broken, please report a problem.
+        </Text>
         <Button
           variant="primaryOutline"
           borderRadius="full"
@@ -42,5 +46,5 @@ export default function NotFound() {
         </Button>
       </Flex>
     </Flex>
-  )
+  );
 }

--- a/frontend/src/pages/admin/login/Main.tsx
+++ b/frontend/src/pages/admin/login/Main.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { ADMIN_LOGIN } from "../../../gql/mutations";
 import { isAdmin, isRelief } from "../../../utils/checkRole";
-import * as ROUTES from "../../../constants/routes";
+import * as ROUTES from "../../../constants/Routes";
 import Loading from "../../Loading";
 
 export default function AdminLoginPage() {
@@ -58,7 +58,7 @@ export default function AdminLoginPage() {
   };
 
   if (!checkLoggedIn || loading) {
-    return <Loading />
+    return <Loading />;
   }
 
   if (loggedIn) {
@@ -86,7 +86,7 @@ export default function AdminLoginPage() {
         <Flex width="30%" marginLeft="3vw">
           <img
             width="100%"
-            src={ process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png" }
+            src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"}
             alt="Marillac Place Logo"
           />
         </Flex>
@@ -104,13 +104,9 @@ export default function AdminLoginPage() {
           gap="20px"
         >
           <Flex flexDir="column">
-            <Text textStyle="web.h1">
-              Sign in
-            </Text>
+            <Text textStyle="web.h1">Sign in</Text>
 
-            <Text textStyle="web.b1">
-              Please enter your login information.
-            </Text>
+            <Text textStyle="web.b1">Please enter your login information.</Text>
           </Flex>
 
           <Flex flexDir="column" gap="10px">
@@ -136,7 +132,11 @@ export default function AdminLoginPage() {
               />
             </FormControl>
 
-            { error && <Text textStyle="web.b2" fontWeight="600" color="#E30000">{error}</Text> }
+            {error && (
+              <Text textStyle="web.b2" fontWeight="600" color="#E30000">
+                {error}
+              </Text>
+            )}
           </Flex>
 
           <Button
@@ -154,4 +154,4 @@ export default function AdminLoginPage() {
       </Flex>
     </Flex>
   );
-};
+}

--- a/frontend/src/pages/participant/login/Main.tsx
+++ b/frontend/src/pages/participant/login/Main.tsx
@@ -1,16 +1,10 @@
 import React, { useState, useEffect } from "react";
-import {Navigate, useNavigate } from "react-router-dom";
-import {
-  Button,
-  Flex,
-  Text,
-  Input,
-  FormControl,
-} from "@chakra-ui/react";
+import { Navigate, useNavigate } from "react-router-dom";
+import { Button, Flex, Text, Input, FormControl } from "@chakra-ui/react";
 import { useMutation } from "@apollo/client";
 import { isParticipant } from "../../../utils/checkRole";
 import { PARTICIPANT_LOGIN } from "../../../gql/mutations";
-import * as ROUTES from "../../../constants/routes";
+import * as ROUTES from "../../../constants/Routes";
 import Loading from "../../Loading";
 
 export default function ParticipantsLoginPage() {
@@ -56,7 +50,7 @@ export default function ParticipantsLoginPage() {
   };
 
   if (!checkLoggedIn || loading) {
-    return <Loading />
+    return <Loading />;
   }
 
   if (loggedIn) {
@@ -82,7 +76,7 @@ export default function ParticipantsLoginPage() {
         <Flex width="75%">
           <img
             width="100%"
-            src={ process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png" }
+            src={process.env.REACT_APP_FRONTEND_URL + "/assets/logo.png"}
             alt="Marillac Place Logo"
           />
         </Flex>
@@ -97,9 +91,7 @@ export default function ParticipantsLoginPage() {
           borderColor="neutral.300"
         >
           <Flex flexDir="column">
-            <Text textStyle="mobile.h1">
-              Sign in
-            </Text>
+            <Text textStyle="mobile.h1">Sign in</Text>
 
             <Text textStyle="mobile.b1">
               Please enter your login information.
@@ -126,7 +118,11 @@ export default function ParticipantsLoginPage() {
             />
           </FormControl>
 
-          { error && <Text textStyle="mobile.b2" fontWeight="600" color="#E30000">{error}</Text> }
+          {error && (
+            <Text textStyle="mobile.b2" fontWeight="600" color="#E30000">
+              {error}
+            </Text>
+          )}
 
           <Button
             width="full"
@@ -143,4 +139,4 @@ export default function ParticipantsLoginPage() {
       </Flex>
     </Flex>
   );
-};
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Get-Participants-By-Rooms-1fb10f3fb1dc809089c5e20c023967d6#1f910f3fb1dc801d9825c370a3622133)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a new GraphQL query resolver getParticipantsByRooms that takes a list of room numbers and returns a mapping of room numbers to participant IDs for current residents.
* Implemented the corresponding service method using Prisma to efficiently fetch all current participants in the specified rooms.
* Updated the GraphQL schema and middleware to expose and secure the new endpoint.
* Set it up to return null for room if the room is empty


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to localhost:5000/graphql and set up the HTTP Header
2. Add test data to db by running the following sql command
```
INSERT INTO participant (
  participant_id, password, room_number, arrival_date, account_creation_date, marillac_bucks
) VALUES
  (101, 'testpass1', 1, '2024-06-01', '2024-06-01', 100),
  (102, 'testpass2', 2, '2024-06-02', '2024-06-02', 150),
  (103, 'testpass3', 3, '2024-06-03', '2024-06-03', 200);
```
3. Run the following query
```
query {
     getParticipantsByRooms(room_numbers: [101, 102, 103, 104])
   }
```
4. Ensure the following is returned
```
{
  "data": {
    "getParticipantsByRooms": {
      "101": 1,
      "102": 2,
      "103": 3,
      "104": null
    }
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Implementation of the resolver in /marillac-place/backend/services/implementation/participantImplementation.ts



## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
