### PR TITLE
integrated editing function with announcement modal ui

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ import ParticipantLoginPage from "./pages/participant/login/Main";
 
 import NotFound from "./pages/NotFound";
 
-import * as ROUTES from "./constants/routes";
+import * as ROUTES from "./constants/Routes";
 import AdminRoute from "./components/admin/AdminRoute";
 import ParticipantRoute from "./components/participant/ParticipantRoute";
 

--- a/frontend/src/components/admin/AdminRoute.tsx
+++ b/frontend/src/components/admin/AdminRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from "react-router-dom";
 import { Flex } from "@chakra-ui/react";
 import SideBar from "./SideBar";
 import Notification from "./Notification";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 import { isAdmin, isRelief } from "../../utils/checkRole";
 import Loading from "../../pages/Loading";
 

--- a/frontend/src/components/admin/SideBar.tsx
+++ b/frontend/src/components/admin/SideBar.tsx
@@ -13,7 +13,7 @@ import {
   ModalBody,
   Text
 } from "@chakra-ui/react";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 
 type SideBarTabProps = {
   label: string,

--- a/frontend/src/components/participant/ParticipantRoute.tsx
+++ b/frontend/src/components/participant/ParticipantRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { Flex } from "@chakra-ui/react";
-import * as ROUTES from "../../constants/routes";
+import * as ROUTES from "../../constants/Routes";
 import { isParticipant } from "../../utils/checkRole";
 import Loading from "../../pages/Loading";
 

--- a/frontend/src/gql/mutations.ts
+++ b/frontend/src/gql/mutations.ts
@@ -93,19 +93,14 @@ export const CREATE_ANNOUNCEMENT = gql`
 `;
 
 export const EDIT_ANNOUNCEMENT = gql`
-  mutation editAnnouncement($announcementId: number,
-    $from: StaffType,     
-    $to: [Int],          
-    $priority: PriorityType,   
-    $createdAt: Date,
-    $message: String,
-    ) {
+  mutation editAnnouncement(
+    $announcement_id: Int!,
+    $priority: Priority,
+    $message: String
+  ) {
     editAnnouncement(
-      announcementId: $announcementId
-      from: $from
-      to: $to
-      priority: $priority
-      createdAt: $createdAt
+      announcement_id: $announcement_id,
+      priority: $priority,
       message: $message
     )
   }

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Flex, Text } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
-import * as ROUTES from "../constants/routes";
+import * as ROUTES from "../constants/Routes";
 
 export default function NotFound() {
   const navigate = useNavigate();

--- a/frontend/src/pages/admin/announcements/Main.tsx
+++ b/frontend/src/pages/admin/announcements/Main.tsx
@@ -2,12 +2,25 @@ import { Flex, Text, Button, VStack } from "@chakra-ui/react";
 import AddIcon from "@mui/icons-material/Add";
 import React, { useState } from "react";
 import AnnouncementCard from "./elements/AnnouncementCard";
+import EditAnnouncementModal from "./elements/EditAnnouncementModal"; // adjust path
 
 export default function AdminAnnouncementsPage() {
   const [selectedButtons, setSelectedButtons] = useState<boolean[]>(
     new Array(10).fill(false)
   ); // Keeping track of buttons on and off
 
+  const [currentAnnouncement, setCurrentAnnouncement] = useState({
+  id: 1,
+  priority: "NORMAL",
+  message: "",
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const onEdit = (announcement: { id: number; priority: string; message: string }) => {
+    setCurrentAnnouncement(announcement);
+    setIsModalOpen(true);
+  };
   const handleButtonClick = (id: number) => {
     setSelectedButtons((prevSelected) => {
       const newSelected = [...prevSelected];
@@ -173,9 +186,18 @@ export default function AdminAnnouncementsPage() {
             message={item.message}
             timestamp={item.timestamp}
             importance={item.importance}
+            onEdit={() => onEdit(currentAnnouncement)}
+
           />
         ))}
       </VStack>
+        <EditAnnouncementModal
+    isOpen={isModalOpen}
+    setIsOpen={setIsModalOpen}
+    announcementId={currentAnnouncement.id}
+    initialMessage={currentAnnouncement.message}
+    initialPriority={currentAnnouncement.priority}
+  />
     </Flex>
   );
 }

--- a/frontend/src/pages/admin/announcements/elements/AnnouncementCard.tsx
+++ b/frontend/src/pages/admin/announcements/elements/AnnouncementCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import { Box, Text, IconButton, Flex } from "@chakra-ui/react";
 import PriorityHighOutlinedIcon from "@mui/icons-material/PriorityHighOutlined";
 import EditIcon from "@mui/icons-material/Edit";
@@ -9,6 +9,7 @@ type AnnouncementCardProps = {
   message: string;
   timestamp: string;
   importance?: 0 | 1 | 2;
+  onEdit?: () => void;
 };
 
 export default function AnnouncementCard({
@@ -16,6 +17,7 @@ export default function AnnouncementCard({
   message,
   timestamp,
   importance = 0,
+  onEdit,
 }: AnnouncementCardProps) {
   return (
     <Box
@@ -65,7 +67,7 @@ export default function AnnouncementCard({
             icon={<EditIcon sx={{ fontSize: "18px", color: "#808080" }} />}
             size="sm"
             variant="ghost"
-            onClick={() => console.log("Edit clicked")}
+            onClick={onEdit}
           />
           <IconButton
             aria-label="Delete"

--- a/frontend/src/pages/admin/announcements/elements/EditAnnouncementModal.tsx
+++ b/frontend/src/pages/admin/announcements/elements/EditAnnouncementModal.tsx
@@ -16,25 +16,81 @@ import {
   Stack,
   Textarea,
   Box,
+  useToast
 } from "@chakra-ui/react";
 import PriorityHighOutlinedIcon from "@mui/icons-material/PriorityHighOutlined";
+import { useMutation } from "@apollo/client";
+import { EDIT_ANNOUNCEMENT } from "../../../../gql/mutations";
+
 
 type EditAnnouncementModalProps = {
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  announcementId: number;
+  initialMessage: string;
+  initialPriority: string;
 };
 
 const EditAnnouncementModal = ({
   isOpen,
   setIsOpen,
+  announcementId,
+  initialMessage,
+  initialPriority,
 }: EditAnnouncementModalProps): React.ReactElement => {
-  const [priority, setPriority] = useState("");
+  const [priority, setPriority] = useState(initialPriority);
   const [sendTo] = useState("");
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState(initialMessage);
 
-  const handleSave = () => {
-    console.log("Saving announcement:", { sendTo, priority, message });
-    setIsOpen(false);
+  const [editAnnouncement] = useMutation(EDIT_ANNOUNCEMENT);
+  const toast = useToast();
+
+  const handleSave = async () => {
+
+    if (!announcementId || !priority || !message.trim()) {
+      toast({
+        title: "Missing Fields",
+        description: "All fields must be filled in.",
+        status: "error",
+        duration: 4000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    try {
+      await editAnnouncement({
+        variables: {
+          announcement_id: announcementId,
+          priority,
+          message,
+        },
+      });
+
+      toast({
+        title: "Success",
+        description: "Announcement updated.",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+
+      setIsOpen(false);
+      window.location.reload();
+  } catch (error: any) {
+    console.error("Edit error:", error);
+    console.error("GraphQL error details:", error.graphQLErrors);
+    console.error("Network error details:", error.networkError);
+
+    toast({
+      title: "Error",
+      description: "Failed to update announcement.",
+      status: "error",
+      duration: 4000,
+      isClosable: true,
+    });
+}
+
   };
 
   const handleCancel = () => {

--- a/frontend/src/pages/admin/login/Main.tsx
+++ b/frontend/src/pages/admin/login/Main.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { ADMIN_LOGIN } from "../../../gql/mutations";
 import { isAdmin, isRelief } from "../../../utils/checkRole";
-import * as ROUTES from "../../../constants/routes";
+import * as ROUTES from "../../../constants/Routes";
 import Loading from "../../Loading";
 
 export default function AdminLoginPage() {

--- a/frontend/src/pages/participant/login/Main.tsx
+++ b/frontend/src/pages/participant/login/Main.tsx
@@ -10,7 +10,7 @@ import {
 import { useMutation } from "@apollo/client";
 import { isParticipant } from "../../../utils/checkRole";
 import { PARTICIPANT_LOGIN } from "../../../gql/mutations";
-import * as ROUTES from "../../../constants/routes";
+import * as ROUTES from "../../../constants/Routes";
 import Loading from "../../Loading";
 
 export default function ParticipantsLoginPage() {


### PR DESCRIPTION
## Notion ticket link
Edit Announcement Function
(https://www.notion.so/uwblueprintexecs/Edit-Announcement-Function-1fb10f3fb1dc8041842ed9abb87b09eb)

## Implementation description
- began by creating a function to handle editing once the edit button is clicked
- it validates that the required fields are complete, and if so attempts to use editAnnouncement mutation
- also modified editAnnouncement mutation to match the one in the backend folder
- used useToast from chakraui to display updates on the frontend, with an error if the mutation was unsuccesful, and a success if it was
- integrated this edit functionality with the edit announcement modal created earlier
- rendered edit announcement modal in main.tsx, and added logic for opening/closing of the modal in parent component (main.tsx)
- created a state for announcement contents including id, message and priority, which can later be updated by getting these details from db


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. In the announcements page, click the edit icon on the announcement card
2. make your changes to the announcement, and click save changes
3. go to your local db and check the announcements table, you should see your updated announcement
4. if you get an error while updating the announcement on the frontend, it may be due to the fact that your announcements table is empty/there is no announcement with that given id.
If necessary, write to the db ex:
```
INSERT INTO announcement (announcement_id, priority, creation_date, message)
VALUES (1, 'HIGH', NOW(), 'test announcement!');
```

## What should reviewers focus on?
- Want to make sure that there are no additional functionalities/ edge cases that i may have missed
- want to make sure that initial states (announcement id, initial messsage, initial priority) should be passed down. 


## Checklist
- [✅ ] My PR name is descriptive and in imperative tense
- [ ✅] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [✅ ] I have run the appropriate linter(s)
- [✅ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
