### PR TITLE
Yan/update goals

### DIFF
--- a/backend/resolvers/participantResolver.ts
+++ b/backend/resolvers/participantResolver.ts
@@ -106,6 +106,21 @@ const participantResolver = {
         reason
       );
     },
+    updateMarillacBucksGoal: async (
+      _parent: undefined,
+      {
+        participant_id,
+        marillac_bucks_goal,
+      }: {
+        participant_id: number;
+        marillac_bucks_goal: number;
+      }
+    ): Promise<boolean> => {
+      return participantService.updateMarillacBucksGoal(
+        participant_id,
+        marillac_bucks_goal
+      );
+    },
   },
 };
 

--- a/backend/services/implementation/participantImplementation.ts
+++ b/backend/services/implementation/participantImplementation.ts
@@ -191,6 +191,21 @@ class ParticipantService implements IParticipantService {
       throw new Error("Something went wrong");
     }
   }
+
+  async updateMarillacBucksGoal(
+    participant_id: number,
+    marillac_bucks_goal: number
+  ): Promise<boolean> {
+    try {
+      await prisma.participant.update({
+        where: { participant_id },
+        data: { marillac_bucks_goal },
+      });
+      return true;
+    } catch (err) {
+      throw new Error("Something went wrong");
+    }
+  }
   //
   //     async getParticipantByRoom(roomNumber: number): Promise<Participant | null> {
   //         try {

--- a/backend/services/interface/participantInterface.ts
+++ b/backend/services/interface/participantInterface.ts
@@ -30,6 +30,10 @@ interface IParticipantService {
     marillac_bucks: number,
     reason: string
   ): Promise<boolean>;
+  updateMarillacBucksGoal(
+    participant_id: number,
+    marillac_bucks_goal: number
+  ): Promise<boolean>;
   // updateParticipantById(
   //   participantId: string,
   //   roomNumber?: number,

--- a/backend/types/resolvers.ts
+++ b/backend/types/resolvers.ts
@@ -43,6 +43,10 @@ const resolvers = gql`
       marillac_bucks: Int!
       reason: String!
     ): Boolean
+    updateMarillacBucksGoal(
+      participant_id: Int!
+      marillac_bucks_goal: Int
+    ): Boolean
     createNote(message: String!): Boolean
     deleteNote(note_id: Int!): Boolean
     createAnnouncement(

--- a/backend/utils/getGraphQLMiddleware.ts
+++ b/backend/utils/getGraphQLMiddleware.ts
@@ -49,6 +49,7 @@ export default function getGraphQLMiddleware() {
       createParticipant: verifyRole(["admin", "relief"]),
       updateParticipant: verifyRole(["admin", "relief"]),
       updateMarillacBucks: verifyRole(["admin", "relief"]),
+      updateMarillacBucksGoal: verifyRole(["admin", "relief"]),
       createNote: verifyRole(["admin", "relief"]),
       deleteNote: verifyRole(["admin", "relief"]),
       createAnnouncement: verifyRole(["admin", "relief"]),


### PR DESCRIPTION
Adds a new GraphQL mutation updateMarillacBucksGoal that allows 
for setting and updating a participant's Marillac Bucks goal.

The mutation takes a participant ID and a Marillac Bucks
amount as input, and updates the marillac_bucks_goal property
for the corresponding participant in the database.