### PR TITLE
updated pr for elsieyli's backend ticket #201

### DIFF
--- a/backend/resolvers/badgeResolver.ts
+++ b/backend/resolvers/badgeResolver.ts
@@ -42,7 +42,16 @@ const badgeResolver = {
           name: 'asc'
         },
       });
-    }
+    },
+    getEarnedBadgesByParticipant: async (
+      _parent: undefined,
+      { participantId }: { participantId: number }
+    ): Promise<EarnedBadge[]> => {
+      return prisma.earnedBadge.findMany({
+        where: { participant_id: participantId },
+        orderBy: { date_received: "desc" },
+      });
+    },
   },
 
   Mutation: {

--- a/backend/types/resolvers.ts
+++ b/backend/types/resolvers.ts
@@ -16,6 +16,7 @@ const resolvers = gql`
     getCustomBadges: [Badge]
     getSystemBadges: [Badge]
     hasCompletedAllRequiredTasks(participantId: Int!): Boolean
+    getEarnedBadgesByParticipant(participantId: Int!): [EarnedBadge!]!
   }
 
   type Mutation {

--- a/backend/utils/getGraphQLMiddleware.ts
+++ b/backend/utils/getGraphQLMiddleware.ts
@@ -45,6 +45,7 @@ export default function getGraphQLMiddleware() {
       getCustomBadges: verifyRole(["admin", "relief"]),
       getSystemBadges: verifyRole(["admin", "relief"]),
       hasCompletedAllRequiredTasks: verifyRole(["participant"]),
+      getEarnedBadgesByParticipant: verifyRole(["admin", "participant"]),
     },
     Mutation: {
       createParticipant: verifyRole(["admin", "relief"]),


### PR DESCRIPTION
## Ticket
<!-- Replace with your ticket's URL -->
[Elsiey's Old Backend Ticket #201](https://github.com/uwblueprint/marillac-place/pull/201)


<!-- A quick summary of the implementation details -->
## Summary
(Copied from old PR)
- Exposed getEarnedBadgesByParticipant(participantId: Int!) in SDL
- Added getEarnedBadgesByParticipant to IBadgeService & BadgeService
- Wired resolver into existing badgeResolver

## Testing Details
Tested using the following query (this is without the auth token, add it if your testing):
```
query { getEarnedBadgesByParticipant(participantId: 1) { earned_badge_id badge_id participant_id name description badge_icon level date_received } }
```

The earned_badge table maybe empty, so this insert query maybe useful:
```
INSERT INTO earned_badge (participant_id, badge_id, date_received, name, description, badge_icon, level)
VALUES (
  1,                                -- participant_id (you requested this be 1)
  15,                                -- badge_id (replace with a real badge_id from step 2 or the RETURNING value)
  '2025-10-25T18:00:00Z',           -- date_received (ISO string)
  'Test Earned Badge',              -- name
  'Test insert for getEarnedBadgesByParticipant', -- description
  'FIVE_STAR',                           -- badge_icon (replace with a valid Icon enum value)
  1                                 -- level
);
```


## Checklist
- [X] All of my containers are healthy and not producing any error messages
- [X] The frontend and backend ports are set to 3000 & 5000, respectively
- [X] If new packages were installed, I ran yarn install, and there is no package-lock.json file present in the codebase
