### PR TITLE
Updating marillac bucks creates transaction

### DIFF
--- a/backend/resolvers/participantResolver.ts
+++ b/backend/resolvers/participantResolver.ts
@@ -1,4 +1,9 @@
-import { Participant, Prisma, PrismaClient } from "@prisma/client";
+import {
+  Participant,
+  Prisma,
+  PrismaClient,
+  TransactionType,
+} from "@prisma/client";
 import { getToday } from "../utils/formatDateTime";
 import { checkAndRecordGoalReached } from "../utils/checkGoalReached";
 
@@ -258,16 +263,60 @@ const participantResolver = {
       {
         participant_id,
         marillac_bucks,
+        reason,
       }: {
         participant_id: number;
         marillac_bucks: number;
         reason: string;
       }
     ): Promise<boolean> => {
-      await prisma.participant.update({
+      // Get current participant to check balance
+      const participant = await prisma.participant.findUnique({
         where: { participant_id },
-        data: { marillac_bucks },
+        select: { marillac_bucks: true },
       });
+
+      if (!participant) {
+        throw new Error("Participant not found");
+      }
+
+      const currentBalance = participant.marillac_bucks;
+      const difference = marillac_bucks - currentBalance;
+      const isIncreasing = difference > 0;
+
+      // If no change, just return (no transaction needed)
+      if (difference === 0) {
+        return true;
+      }
+
+      // Check for sufficient funds if removing bucks
+      if (!isIncreasing && currentBalance < Math.abs(difference)) {
+        throw new Error(
+          "Insufficient funds. Cannot remove more than current balance."
+        );
+      }
+
+      // Determine transaction type
+      const transactionType = isIncreasing
+        ? TransactionType.REFUND
+        : TransactionType.PURCHASE;
+
+      // Update participant balance and create transaction in a transaction
+      await prisma.$transaction([
+        prisma.participant.update({
+          where: { participant_id },
+          data: { marillac_bucks },
+        }),
+        prisma.transaction.create({
+          data: {
+            participant_id,
+            transaction_date: getToday(),
+            transaction_type: transactionType,
+            description: reason,
+            marillac_bucks: Math.abs(difference),
+          },
+        }),
+      ]);
 
       // Check if this update caused the participant to reach their goal
       await checkAndRecordGoalReached(participant_id);

--- a/frontend/src/admin/pages/schedule/components/MarillacBalanceModal.tsx
+++ b/frontend/src/admin/pages/schedule/components/MarillacBalanceModal.tsx
@@ -38,7 +38,7 @@ export default function MarillacBalanceModal({
     if (numericAmount <= 0) {
       setError("Amount must be positive");
     } else if (numericAmount > currentBalance && action === "remove") {
-      setError("Cannot remove an amount greater than the current balance");
+      setError("Insufficient funds. Cannot remove more than current balance.");
     } else {
       let newBalance = currentBalance;
       if (action === "add") {


### PR DESCRIPTION

## Summary
Update Marillac Bucks query now creates transaction

<!-- A quick summary of how you tested your changes -->
## Testing Details
This can be tested by going to the schedule page on the admin page, and updating the marillac bucks for a participant in their respective rooms.

<!-- Draw attention to anything you'd like a second opinion on or something extra you've included that is not apart of your assigned ticket -->
## Additional Information
This was accomplished by updating the updateMarillacBucks mutation, should we consider having this as a seperate mutation or passing a variable to determine if it was being done by admin or a task.

## Checklist
- [ ] All of my containers are healthy and not producing any error messages
- [ ] The frontend and backend ports are set to 3000 & 5000, respectively
- [ ] If new packages were installed, I ran yarn install, and there is no package-lock.json file present in the codebase
