### PR TITLE
Badge Logic (Jack of All Trades, First Goal, Individual Goal) #319

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Backend: http://localhost:5000/graphql
 
 ## Database Interactions
 Apply / migrate changes in prisma.schema to the database:
-1. Change the DATABASE_URL in the backend .env file to: postgresql://postgres:postgres@**localhost**:5432/mp
-2. In your terminal, run `npx prisma migrate dev` in the backend folder and follow the prompts
-3. Don’t forget to reset DATABASE_URL back to postgresql://postgres:postgres@**mp_db**:5432/mp
+1. First ensure your `mp_db` container is running 
+2. Change the DATABASE_URL in the backend .env file to: postgresql://postgres:postgres@**localhost**:5432/mp
+3. In your terminal, run `npx prisma migrate dev` in the backend folder and follow the prompts
+4. Don’t forget to reset DATABASE_URL back to postgresql://postgres:postgres@**mp_db**:5432/mp
 
 Common database commands:
 ```bash

--- a/backend/crons/scripts/assignRequiredTasks.ts
+++ b/backend/crons/scripts/assignRequiredTasks.ts
@@ -66,6 +66,7 @@ async function assignRequiredTasks() {
                     await db.assignedTask.create({
                       data: {
                         pid: participant.pid,
+                        tid: requiredTask.tid,
                         name: requiredTask.name,
                         type: requiredTask.type,
                         value: requiredTask.value,
@@ -84,6 +85,7 @@ async function assignRequiredTasks() {
                     await db.assignedTask.create({
                       data: {
                         pid: participant.pid,
+                        tid: requiredTask.tid,
                         name: requiredTask.name,
                         type: requiredTask.type,
                         value: requiredTask.value,
@@ -134,6 +136,7 @@ async function assignRequiredTasks() {
                     await db.assignedTask.create({
                       data: {
                         pid: participant.pid,
+                        tid: requiredTask.tid,
                         name: requiredTask.name,
                         type: requiredTask.type,
                         value: requiredTask.value,
@@ -152,6 +155,7 @@ async function assignRequiredTasks() {
                     await db.assignedTask.create({
                       data: {
                         pid: participant.pid,
+                        tid: requiredTask.tid,
                         name: requiredTask.name,
                         type: requiredTask.type,
                         value: requiredTask.value,
@@ -181,6 +185,7 @@ async function assignRequiredTasks() {
               await db.assignedTask.create({
                 data: {
                   pid: participant.pid,
+                  tid: requiredTask.tid,
                   name: requiredTask.name,
                   type: requiredTask.type,
                   value: requiredTask.value,

--- a/backend/gql/resolvers/assignedTaskResolver.ts
+++ b/backend/gql/resolvers/assignedTaskResolver.ts
@@ -6,6 +6,9 @@ import { updateBadgeLevelProgress } from "../../utils/badgeUtils";
 import {
   PERFECT_SCORE_OPTIONAL,
   PERFECT_SCORE_REQUIRED,
+  JACK_OF_ALL_TRADES,
+  FIRST_GOAL,
+  INDIVIDUAL_GOAL,
 } from "../../constants/systemBadges";
 
 const assignedTaskResolver = {
@@ -108,6 +111,7 @@ const assignedTaskResolver = {
       _parent: undefined,
       {
         pid,
+        tid,
         name,
         type,
         value,
@@ -117,6 +121,7 @@ const assignedTaskResolver = {
         comment,
       }: {
         pid: number;
+        tid?: number;
         name: string;
         type: TaskType;
         value: number;
@@ -129,6 +134,7 @@ const assignedTaskResolver = {
       return db.assignedTask.create({
         data: {
           pid,
+          tid,
           name,
           type,
           value,
@@ -244,23 +250,49 @@ const assignedTaskResolver = {
           }
         }
 
-        // TODO (victor): add jack of all trades, first goal, individual goal badge logic
-
         // Jack of All Trades:
         // If the task that's just been completed has not been completed before, update badge level progress for the JACK_OF_ALL_TRADES badge by 1
-        // For this badge, you might need to add tid to the AssignedTask table (not as a FK referencing the Task table, just as an attribute, since if the referenced Task is deleted we still want to preserve the state of the AssignedTask)
-        // Places you might need to update with this new property include (types/models.ts, types/resolvers.ts, prisma/schema.prisma, createAssignedTask resolver)
-        // To process new schema changes, you'll need to run the following commands:
-        // npx prisma migrate reset
-        // npx prisma migrate dev
-        // npx @snaplet/seed sync
-        // Also ensure that the mp_db container is running and you've set DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mp after the container is setup
+
+        const hasPreviouslyCompleted = await db.assignedTask
+          .findFirst({
+            where: {
+              tid: assignedTask.tid,
+              status: TaskStatus.COMPLETE,
+              pid: assignedTask.pid,
+            },
+          })
+          .then((task) => task !== null);
+
+        if (!hasPreviouslyCompleted && assignedTask.tid !== null) {
+          await updateBadgeLevelProgress(
+            JACK_OF_ALL_TRADES,
+            assignedTask.pid,
+            1
+          );
+        }
 
         // First Goal:
         // No condition needs to be checked, just call updateBadgeLevelProgress for the FIRST_GOAL badge with inc = 1
+        await updateBadgeLevelProgress(FIRST_GOAL, assignedTask.pid, 1);
 
-        // Individual Goal:
+        // Individual Goal
         // Check if all assigned tasks of type INDIVIDUAL_GOAL have been completed for the week, if so, update badge level progress for the INDIVIDUAL_GOAL badge by 1
+        const individualGoalTasksNotComplete = await db.assignedTask.findMany({
+          where: {
+            pid: assignedTask.pid,
+            type: TaskType.INDIVIDUAL_GOAL,
+            status: { not: TaskStatus.COMPLETE },
+            start_date: { lte: endOfWeek(new Date()) },
+            end_date: { gte: startOfWeek(new Date()) },
+          },
+        });
+
+        if (
+          individualGoalTasksNotComplete.length === 1 &&
+          individualGoalTasksNotComplete[0].aid === aid
+        ) {
+          await updateBadgeLevelProgress(INDIVIDUAL_GOAL, assignedTask.pid, 1);
+        }
       }
 
       return db.assignedTask.update({

--- a/backend/gql/resolvers/assignedTaskResolver.ts
+++ b/backend/gql/resolvers/assignedTaskResolver.ts
@@ -121,7 +121,7 @@ const assignedTaskResolver = {
         comment,
       }: {
         pid: number;
-        tid?: number;
+        tid: number;
         name: string;
         type: TaskType;
         value: number;
@@ -213,7 +213,7 @@ const assignedTaskResolver = {
         );
 
         if (assignedTask.type === TaskType.REQUIRED) {
-          const weeklyRequiredTasks = await db.assignedTask.findMany({
+          const weeklyRequiredTasksNotComplete = await db.assignedTask.findMany({
             where: {
               pid: assignedTask.pid,
               status: { not: TaskStatus.COMPLETE },
@@ -223,7 +223,7 @@ const assignedTaskResolver = {
             },
           });
 
-          if (weeklyRequiredTasks.length === 0) {
+          if (weeklyRequiredTasksNotComplete.length === 1) {
             await updateBadgeLevelProgress(
               PERFECT_SCORE_REQUIRED,
               assignedTask.pid,
@@ -248,10 +248,23 @@ const assignedTaskResolver = {
               1
             );
           }
-        }
+        } else if (assignedTask.type === TaskType.INDIVIDUAL_GOAL) {
+          const individualGoalTasksNotComplete = await db.assignedTask.findMany({
+            where: {
+              pid: assignedTask.pid,
+              type: TaskType.INDIVIDUAL_GOAL,
+              status: { not: TaskStatus.COMPLETE },
+              start_date: { lte: endOfWeek(new Date()) },
+              end_date: { gte: startOfWeek(new Date()) },
+            },
+          });
+  
+          if (individualGoalTasksNotComplete.length === 1) {
+            await updateBadgeLevelProgress(INDIVIDUAL_GOAL, assignedTask.pid, 1);
+          }
 
-        // Jack of All Trades:
-        // If the task that's just been completed has not been completed before, update badge level progress for the JACK_OF_ALL_TRADES badge by 1
+          await updateBadgeLevelProgress(FIRST_GOAL, assignedTask.pid, 1);
+        }
 
         const hasPreviouslyCompleted = await db.assignedTask
           .findFirst({
@@ -262,36 +275,12 @@ const assignedTaskResolver = {
             },
           })
           .then((task) => task !== null);
-
-        if (!hasPreviouslyCompleted && assignedTask.tid !== null) {
+        if (!hasPreviouslyCompleted) {
           await updateBadgeLevelProgress(
             JACK_OF_ALL_TRADES,
             assignedTask.pid,
             1
           );
-        }
-
-        // First Goal:
-        // No condition needs to be checked, just call updateBadgeLevelProgress for the FIRST_GOAL badge with inc = 1
-        await updateBadgeLevelProgress(FIRST_GOAL, assignedTask.pid, 1);
-
-        // Individual Goal
-        // Check if all assigned tasks of type INDIVIDUAL_GOAL have been completed for the week, if so, update badge level progress for the INDIVIDUAL_GOAL badge by 1
-        const individualGoalTasksNotComplete = await db.assignedTask.findMany({
-          where: {
-            pid: assignedTask.pid,
-            type: TaskType.INDIVIDUAL_GOAL,
-            status: { not: TaskStatus.COMPLETE },
-            start_date: { lte: endOfWeek(new Date()) },
-            end_date: { gte: startOfWeek(new Date()) },
-          },
-        });
-
-        if (
-          individualGoalTasksNotComplete.length === 1 &&
-          individualGoalTasksNotComplete[0].aid === aid
-        ) {
-          await updateBadgeLevelProgress(INDIVIDUAL_GOAL, assignedTask.pid, 1);
         }
       }
 

--- a/backend/gql/test.gql
+++ b/backend/gql/test.gql
@@ -607,6 +607,7 @@ mutation UpdateBadgeLevel(
 
 mutation CreateAssignedTask(
   $pid: Int!
+  $tid: Int!
   $name: String!
   $type: TaskType!
   $value: Int!
@@ -617,6 +618,7 @@ mutation CreateAssignedTask(
 ) {
   createAssignedTask(
     pid: $pid
+    tid: $tid
     name: $name
     type: $type
     value: $value
@@ -626,6 +628,7 @@ mutation CreateAssignedTask(
     comment: $comment
   ) {
     aid
+    tid
     pid
     name
     type

--- a/backend/gql/types/models.ts
+++ b/backend/gql/types/models.ts
@@ -23,6 +23,7 @@ const models = gql`
   type AssignedTask {
     aid: Int!
     pid: Int!
+    tid: Int!
     name: String!
     type: TaskType!
     status: TaskStatus!

--- a/backend/gql/types/resolvers.ts
+++ b/backend/gql/types/resolvers.ts
@@ -160,6 +160,7 @@ const resolvers = gql`
 
     createAssignedTask(
       pid: Int!
+      tid: Int!
       name: String!
       type: TaskType!
       value: Int!

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -183,6 +183,7 @@ model Task {
 model AssignedTask {
   aid        Int        @id @default(autoincrement())
   pid        Int
+  tid        Int?
   name       String
   type       TaskType
   status     TaskStatus @default(ASSIGNED)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -183,7 +183,7 @@ model Task {
 model AssignedTask {
   aid        Int        @id @default(autoincrement())
   pid        Int
-  tid        Int?
+  tid        Int
   name       String
   type       TaskType
   status     TaskStatus @default(ASSIGNED)

--- a/backend/prisma/seed/.snaplet/dataModel.json
+++ b/backend/prisma/seed/.snaplet/dataModel.json
@@ -382,6 +382,20 @@
           "maxLength": null
         },
         {
+          "id": "public.assigned_task.tid",
+          "name": "tid",
+          "columnName": "tid",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "id": "public.assigned_task.name",
           "name": "name",
           "columnName": "name",

--- a/backend/prisma/seed/seed.ts
+++ b/backend/prisma/seed/seed.ts
@@ -41,6 +41,7 @@ async function generateMockData(seed: any) {
       password: random.password(),
       room: ret.index + 1,
       arrival: random.date(),
+      departure: null,
       balance: random.number(0, 2500),
     }))
   );

--- a/backend/utils/badgeUtils.ts
+++ b/backend/utils/badgeUtils.ts
@@ -4,7 +4,7 @@ import db from "../prisma";
 import { SYSTEM_BADGES, JACK_OF_ALL_TRADES, PR_LEADER } from "../constants/systemBadges";
 import processEarning from "./transactionUtils";
 
-function getNextBadgeLevel(level: Level) {
+async function getNextBadgeLevel(name: string, level: Level) {
   const levels = [
     Level.NOVICE,
     Level.BRONZE,
@@ -13,8 +13,12 @@ function getNextBadgeLevel(level: Level) {
     Level.DIAMOND,
   ];
   const index = levels.indexOf(level);
-  if (index === 4) return null;
-  return levels[index + 1];
+  if (index === levels.length - 1) return null;
+  const nextLevel = levels[index + 1];
+  const nextBadgeLevel = await db.badgeLevel.findUnique({
+    where: { name_level: { name, level: nextLevel } },
+  });
+  return nextBadgeLevel?.level;
 }
 
 export async function initBadgeLevelProgress(pid: number) {
@@ -122,7 +126,10 @@ export async function updateBadgeLevelProgress(
       reasonForEarning
     );
 
-    const nextBadgeLevel = getNextBadgeLevel(badgeLevelProgress.level);
+    const nextBadgeLevel = await getNextBadgeLevel(
+      name,
+      badgeLevelProgress.level
+    );
     if (!nextBadgeLevel) return;
     await db.badgeLevelProgress.create({
       data: { name, level: nextBadgeLevel, pid, progress: newAmount },

--- a/frontend/src/gql/assignedTaskRequests.ts
+++ b/frontend/src/gql/assignedTaskRequests.ts
@@ -49,6 +49,7 @@ export const HAS_COMPLETED_ALL_REQUIRED_TASKS = gql`
 export const CREATE_ASSIGNED_TASK = gql`
   mutation createAssignedTask(
     $pid: Int!
+    $tid: Int!
     $name: String!
     $type: TaskType!
     $value: Int!
@@ -59,6 +60,7 @@ export const CREATE_ASSIGNED_TASK = gql`
   ) {
     createAssignedTask(
       pid: $pid
+      tid: $tid
       name: $name
       type: $type
       value: $value
@@ -68,6 +70,7 @@ export const CREATE_ASSIGNED_TASK = gql`
       comment: $comment
     ) {
       aid
+      tid
       pid
       name
       type

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -33,6 +33,7 @@ export interface Announcement {
 export interface AssignedTask {
   aid: number;
   pid: number;
+  tid: number;
   name: string;
   type: TaskType;
   status: TaskStatus;

--- a/frontend/src/ui/UI.tsx
+++ b/frontend/src/ui/UI.tsx
@@ -113,6 +113,7 @@ export default function UI() {
   const assignedTasks: AssignedTask[] = [
     {
       aid: 1,
+      tid: 1,
       pid: 1,
       name: "Task 1",
       type: TaskType.REQUIRED,
@@ -125,6 +126,7 @@ export default function UI() {
     },
     {
       aid: 2,
+      tid: 2,
       pid: 1,
       name: "Task 2",
       type: TaskType.OPTIONAL,
@@ -137,6 +139,7 @@ export default function UI() {
     },
     {
       aid: 3,
+      tid: 3,
       pid: 1,
       name: "Task 3",
       type: TaskType.OPTIONAL,
@@ -159,6 +162,7 @@ export default function UI() {
     },
     {
       aid: 4,
+      tid: 4,
       pid: 1,
       name: "Task 4",
       type: TaskType.INDIVIDUAL_GOAL,


### PR DESCRIPTION
## Ticket
<!-- Replace with your ticket's URL -->
[Badge Logic (Jack of All Trades, First Goal, Individual Goal) #319
](https://github.com/uwblueprint/marillac-place/issues/319)


<!-- A quick summary of the implementation details -->
## Summary
Checks for if Jack of All Trades, First Goal, Individual Goal upon a updateAssignedTask mutation

<!-- A quick summary of how you tested your changes -->
## Testing Details
### Setup: 
```
INSERT INTO assigned_task (
  pid,
  tid,
  name,
  type,
  status,
  value,
  penalty,
  comment,
  start_date,
  end_date
) VALUES (
  1,
  1,
  'Housing Plan',
  'INDIVIDUAL_GOAL',
  'ASSIGNED',
  1,
  0,
  'Complete all assigned chores by end of week',
  NOW(),
  NOW() + INTERVAL '7 days'
);
```

### Query:
```
mutation UpdateAssignedTaskStatus($aid: Int!, $status: TaskStatus!) {
  updateAssignedTaskStatus(aid: $aid, status: $status) {
    aid
    pid
    name
    status
  }
}
```

### Variables:
```
{
    "aid": 1,
    "status": "COMPLETE"
}
```
### Result:

#### badge_level_progress table
<img width="614" height="254" alt="Screenshot 2025-11-19 at 12 14 21 AM" src="https://github.com/user-attachments/assets/2e182040-669c-4d20-8a42-acfea0fdca95" />

#### participant table
<img width="851" height="154" alt="Screenshot 2025-11-19 at 12 14 43 AM" src="https://github.com/user-attachments/assets/f394a8b5-574a-4f46-88af-11bb1145c118" />

#### assigned_task table
<img width="816" height="158" alt="Screenshot 2025-11-19 at 12 13 38 AM" src="https://github.com/user-attachments/assets/d23624eb-98c8-4097-a1b4-535c9a83ad5e" />


<!-- Draw attention to anything you'd like a second opinion on or something extra you've included that is not apart of your assigned ticket -->
## Additional Information
...

## Checklist
- [ ] All of my containers are healthy and not producing any error messages
- [ ] The frontend and backend ports are set to 3000 & 5000, respectively
- [ ] If new packages were installed, I ran yarn install, and there is no package-lock.json file present in the codebase
