### PR TITLE
[F26] Increase idle timeout

### DIFF
--- a/backend/constants/auth.ts
+++ b/backend/constants/auth.ts
@@ -1,0 +1,10 @@
+import { SignOptions } from "jsonwebtoken";
+
+export const DEFAULT_JWT_EXPIRES_IN: NonNullable<SignOptions["expiresIn"]> =
+  "7d";
+
+export function getJwtExpiresIn(): NonNullable<SignOptions["expiresIn"]> {
+  return (process.env.JWT_EXPIRES_IN || DEFAULT_JWT_EXPIRES_IN) as NonNullable<
+    SignOptions["expiresIn"]
+  >;
+}

--- a/backend/gql/resolvers/loginResolver.ts
+++ b/backend/gql/resolvers/loginResolver.ts
@@ -1,5 +1,6 @@
 import jwt from "jsonwebtoken";
 import { Participant } from "@prisma/client";
+import { getJwtExpiresIn } from "../../constants/auth";
 import * as ROLES from "../../constants/roles";
 import { LOGIN } from "../../constants/systemBadges";
 import db from "../../prisma";
@@ -37,7 +38,9 @@ const loginResolver = {
       const jwtSecretKey = process.env.JWT_SECRET ?? "";
       if (!jwtSecretKey) throw new Error("jwt key missing");
 
-      const token = jwt.sign({ role }, jwtSecretKey, { expiresIn: "12h" });
+      const token = jwt.sign({ role }, jwtSecretKey, {
+        expiresIn: getJwtExpiresIn(),
+      });
       return { token };
     },
     participantLogin: async (
@@ -84,7 +87,7 @@ const loginResolver = {
       await db.loginHistory.create({ data: { pid } });
 
       const token = jwt.sign({ role: ROLES.PARTICIPANT, pid }, jwtSecretKey, {
-        expiresIn: "12h",
+        expiresIn: getJwtExpiresIn(),
       });
       return { token };
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts,.js",
     "fix": "eslint . --ext .ts,.js --fix",
+    "test:auth-session-duration": "tsx tests/authSessionDuration.test.ts",
     "postinstall": "npx prisma generate && tsc",
     "start": "npx prisma migrate deploy && npx prisma generate && npx @snaplet/seed sync && npx prisma db seed && if [ \"$NODE_ENV\" = \"production\" ]; then node build/server.js; else nodemon -L; fi"
   },

--- a/backend/tests/authSessionDuration.test.ts
+++ b/backend/tests/authSessionDuration.test.ts
@@ -1,0 +1,99 @@
+import assert from "assert";
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { Participant } from "@prisma/client";
+import * as ROLES from "../constants/roles";
+
+const EXPECTED_SESSION_DURATION_SECONDS = 7 * 24 * 60 * 60;
+const TEST_PASSWORD = "test-password";
+const TEST_PID = 123;
+
+function getTokenDurationSeconds(token: string): number {
+  const decodedToken = jwt.decode(token);
+  assert(decodedToken, "Expected login token to be decodable");
+  assert.notStrictEqual(
+    typeof decodedToken,
+    "string",
+    "Expected login token payload to be an object"
+  );
+
+  const payload = decodedToken as JwtPayload;
+  const issuedAt = payload.iat;
+  const expiresAt = payload.exp;
+
+  if (typeof issuedAt !== "number") {
+    throw new Error("Expected token to include iat");
+  }
+
+  if (typeof expiresAt !== "number") {
+    throw new Error("Expected token to include exp");
+  }
+
+  return expiresAt - issuedAt;
+}
+
+function assertTokenDuration(token: string, loginName: string): void {
+  const actualDurationSeconds = getTokenDurationSeconds(token);
+
+  assert.strictEqual(
+    actualDurationSeconds,
+    EXPECTED_SESSION_DURATION_SECONDS,
+    `${loginName} should issue a 7-day JWT, but issued one for ${actualDurationSeconds} seconds`
+  );
+}
+
+async function run(): Promise<void> {
+  process.env.JWT_SECRET = "test-jwt-secret";
+  process.env.ADMIN_STAFF_PASSWORD = TEST_PASSWORD;
+  delete process.env.JWT_EXPIRES_IN;
+
+  const [{ default: loginResolver }, { default: db }] = await Promise.all([
+    import("../gql/resolvers/loginResolver"),
+    import("../prisma"),
+  ]);
+
+  Object.defineProperty(db.participant, "findUnique", {
+    configurable: true,
+    value: async () =>
+      ({
+        pid: TEST_PID,
+        password: TEST_PASSWORD,
+      } as Participant),
+  });
+  Object.defineProperty(db.loginHistory, "findFirst", {
+    configurable: true,
+    value: async () => ({ id: 1 }),
+  });
+  Object.defineProperty(db.loginHistory, "create", {
+    configurable: true,
+    value: async () => ({ id: 1 }),
+  });
+
+  try {
+    const adminLoginResult = await loginResolver.Mutation.adminLogin(
+      undefined,
+      {
+        role: ROLES.ADMIN,
+        password: TEST_PASSWORD,
+      }
+    );
+    assertTokenDuration(adminLoginResult.token, "adminLogin");
+
+    const participantLoginResult =
+      await loginResolver.Mutation.participantLogin(undefined, {
+        pid: TEST_PID,
+        password: TEST_PASSWORD,
+      });
+    assertTokenDuration(participantLoginResult.token, "participantLogin");
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+run()
+  .then(() => {
+    console.log("auth session duration test passed");
+  })
+  .catch((err: Error) => {
+    console.error(err.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Notion ticket link
[[MP] Increase Idle Timeout](https://www.notion.so/uwblueprintexecs/MP-Increase-Idle-Timeout-3b810f3fb1dc8099943dc40af3b869b5?v=63e8bea779664acbb10b1ea094e0fdcc&source=copy_link)

## Implementation description
* Centralizes the backend JWT session duration in `backend/constants/auth.ts`.
* Changes both `adminLogin` and `participantLogin` to use the shared duration helper instead of the previous hard-coded `12h`.
* Defaults auth tokens to `7d` and supports `JWT_EXPIRES_IN` for environment-specific overrides.
* Adds a focused regression test that verifies both login flows issue 7-day JWTs by default.

## Steps to test
1. `cd backend`
2. `npm run test:auth-session-duration`
3. `npm run lint`
4. `git diff --check`

Known local caveat:
- `npx tsc --noEmit` is currently blocked in this checkout because `backend/node_modules` is missing the declared `nodemailer` and `@types/nodemailer` packages:
  `utils/mailUtils.ts(1,24): error TS2307: Cannot find module 'nodemailer' or its corresponding type declarations.`
- This is unrelated to the idle-timeout change.

## What should reviewers focus on?
* Confirm `7d` is the desired default production session duration.
* Confirm `JWT_EXPIRES_IN` is acceptable for environment-specific overrides.
* Confirm increasing session length is acceptable for any shared-device workflows.
* Confirm both admin and participant sign-in flows still behave correctly after reload.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
